### PR TITLE
Changing Service Bus E2E sample to user assigned identity

### DIFF
--- a/E2E/SB-VNET/infra/app/processor.bicep
+++ b/E2E/SB-VNET/infra/app/processor.bicep
@@ -13,6 +13,8 @@ param serviceBusQueueName string = ''
 param serviceBusNamespaceFQDN string = ''
 param instanceMemoryMB int = 2048
 param maximumInstanceCount int = 100
+param identityId string = ''
+param identityClientId string = ''
 
 module processor '../core/host/functions-flexconsumption.bicep' = {
   name: '${serviceName}-functions-python-module'
@@ -20,9 +22,14 @@ module processor '../core/host/functions-flexconsumption.bicep' = {
     name: name
     location: location
     tags: union(tags, { 'azd-service-name': serviceName })
+    identityType: 'UserAssigned'
+    identityId: identityId
     appSettings: union(appSettings,
       {
         ServiceBusConnection__fullyQualifiedNamespace: serviceBusNamespaceFQDN
+        ServiceBusConnection__clientId : identityClientId
+        ServiceBusConnection__credential : 'managedidentity'
+        AzureWebJobsStorage__clientId : identityClientId
         ServiceBusQueueName: serviceBusQueueName
       })
     applicationInsightsName: applicationInsightsName

--- a/E2E/SB-VNET/infra/core/identity/userAssignedIdentity.bicep
+++ b/E2E/SB-VNET/infra/core/identity/userAssignedIdentity.bicep
@@ -1,0 +1,14 @@
+param identityName string
+param location string
+param tags object = {}
+
+resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-07-31-preview' = {
+  name: identityName
+  location: location
+  tags: tags
+}
+
+output identityId string = userAssignedIdentity.id
+output identityName string = userAssignedIdentity.name
+output identityPrincipalId string = userAssignedIdentity.properties.principalId
+output identityClientId string = userAssignedIdentity.properties.clientId


### PR DESCRIPTION
The End to End Service Bus sample in this repo used System Assigned Managed Identity between the Flex Consumption function app and storage and service bus. This PR changes the managed identity type to user assigned identity instead as that is recommended. 
