### PR TITLE
Enable AppInsights for specific location

### DIFF
--- a/IaC/bicep/main.bicep
+++ b/IaC/bicep/main.bicep
@@ -6,8 +6,9 @@ targetScope = 'subscription'
 param environmentName string
 @minLength(1)
 @description('Primary location for all resources')
-@allowed(['australiaeast', 'eastasia', 'eastus', 'eastus2', 'northeurope', 'southcentralus', 'southeastasia', 'swedencentral', 'uksouth', 'westus2'])
+@allowed(['australiaeast', 'eastasia', 'eastus', 'eastus2', 'northeurope', 'southcentralus', 'southeastasia', 'swedencentral', 'uksouth', 'westus2', 'eastus2euap'])
 param location string 
+param appInsightsLocation string = ''
 param resourceGroupName string = ''
 param functionPlanName string = ''
 param functionAppName string = ''
@@ -37,6 +38,8 @@ var tags = {
   'azd-env-name': environmentName
 }
 
+var monitoringLocation = !empty(appInsightsLocation) ? appInsightsLocation : location
+
 resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
   location: location
   tags: tags
@@ -48,7 +51,7 @@ module monitoring './core/monitor/monitoring.bicep' = {
   name: 'monitoring'
   scope: rg
   params: {
-    location: location
+    location: monitoringLocation
     tags: tags
     logAnalyticsName: !empty(logAnalyticsName) ? logAnalyticsName : '${abbrs.operationalInsightsWorkspaces}${resourceToken}'
     applicationInsightsName: !empty(applicationInsightsName) ? applicationInsightsName : '${abbrs.insightsComponents}${resourceToken}'


### PR DESCRIPTION
## Purpose

The IaC template sample will fail when the location is not allowed for the `application insights`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

*  Deploy it by myself.

* Test the code

```
* Copy `main.bicepparam` with the location that is not allowed for app insights. (e.g. eastus2euap)
* Specify the ` appInsightsLocation` for eastus2.
* Deploy the app.
```

