### PR TITLE
Restrict E2E and starter templates to supported regions

### DIFF
--- a/E2E/BLOB-PDF/infra/main.bicep
+++ b/E2E/BLOB-PDF/infra/main.bicep
@@ -7,6 +7,12 @@ param environmentName string
 
 @minLength(1)
 @description('Primary location for all resources')
+@allowed(['australiaeast', 'eastasia', 'eastus', 'eastus2', 'northeurope', 'southcentralus', 'southeastasia', 'swedencentral', 'uksouth', 'westus2', 'eastus2euap'])
+@metadata({
+  azd: {
+    type: 'location'
+  }
+})
 param location string
 
 param processorServiceName string = ''

--- a/E2E/HTTP-VNET-EH/infra/main.bicep
+++ b/E2E/HTTP-VNET-EH/infra/main.bicep
@@ -7,6 +7,12 @@ param environmentName string
 
 @minLength(1)
 @description('Primary location for all resources')
+@allowed(['australiaeast', 'eastasia', 'eastus', 'eastus2', 'northeurope', 'southcentralus', 'southeastasia', 'swedencentral', 'uksouth', 'westus2', 'eastus2euap'])
+@metadata({
+  azd: {
+    type: 'location'
+  }
+})
 param location string
 
 // Optional parameters to override the default azd resource naming conventions. Update the main.parameters.json file to provide values. e.g.,:

--- a/E2E/SB-VNET/infra/main.bicep
+++ b/E2E/SB-VNET/infra/main.bicep
@@ -7,6 +7,12 @@ param environmentName string
 
 @minLength(1)
 @description('Primary location for all resources')
+@allowed(['australiaeast', 'eastasia', 'eastus', 'eastus2', 'northeurope', 'southcentralus', 'southeastasia', 'swedencentral', 'uksouth', 'westus2', 'eastus2euap'])
+@metadata({
+  azd: {
+    type: 'location'
+  }
+})
 param location string
 
 @secure()

--- a/starters/http/dotnet/infra/main.bicep
+++ b/starters/http/dotnet/infra/main.bicep
@@ -7,6 +7,12 @@ param environmentName string
 
 @minLength(1)
 @description('Primary location for all resources')
+@allowed(['australiaeast', 'eastasia', 'eastus', 'eastus2', 'northeurope', 'southcentralus', 'southeastasia', 'swedencentral', 'uksouth', 'westus2', 'eastus2euap'])
+@metadata({
+  azd: {
+    type: 'location'
+  }
+})
 param location string
 
 // Optional parameters to override the default azd resource naming conventions. Update the main.parameters.json file to provide values. e.g.,:


### PR DESCRIPTION
## Purpose
Set the allowed locations for flex consumption deployment, so that AZD prompts the user with valid options. Uses the same `@allowed` as from the IaC sample.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Run azd up for a new environment for any of the E2E samples and confirm that the location list is appropriately filtered