### PR TITLE
Adding resource provider registration prerequisite to the E2E samples

### DIFF
--- a/E2E/BLOB-PDF/README.md
+++ b/E2E/BLOB-PDF/README.md
@@ -30,9 +30,10 @@ The communication between the function and the storage account happens via a sys
 
 Before you can run this sample, you must have the following:
 
-- An Azure subscription
-- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
-- [Azure Dev CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd?tabs=winget-windows%2Cbrew-mac%2Cscript-linux&pivots=os-windows)
+* An Azure subscription
+* Ensure both Microsoft.Web and Microsoft.App are [registered resource providers on the Azure subscription](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider)
+* [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
+* [Azure Dev CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd?tabs=winget-windows%2Cbrew-mac%2Cscript-linux&pivots=os-windows)
 
 ## Provision the solution on Azure
 

--- a/E2E/HTTP-VNET-EH/README.md
+++ b/E2E/HTTP-VNET-EH/README.md
@@ -30,6 +30,7 @@ This sample demonstrates a function app running in a Flex Consumption plan that 
 Before you can run this sample, you must have the following:
 
 * An Azure subscription
+* Ensure both Microsoft.Web and Microsoft.App are [registered resource providers on the Azure subscription](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider)
 * [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
 * [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools)
 * [Azure Dev CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd)

--- a/E2E/SB-VNET/README.md
+++ b/E2E/SB-VNET/README.md
@@ -30,6 +30,7 @@ This sample demonstrates a function app running in a Flex Consumption plan that 
 Before you can run this sample, you must have the following:
 
 * An Azure subscription
+* Ensure both Microsoft.Web and Microsoft.App are [registered resource providers on the Azure subscription](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider)
 * [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) or [PowerShell Az Module](https://learn.microsoft.com/powershell/azure/new-azureps-module-az)
 * [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local?tabs=v4%2Clinux%2Ccsharp%2Cportal%2Cbash#install-the-azure-functions-core-tools)
 * [Azure Dev CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd?tabs=winget-windows%2Cbrew-mac%2Cscript-linux&pivots=os-windows)


### PR DESCRIPTION
## Purpose
Adds the Microsoft.Web and Microsoft.App resource provider registration prerequisite to the E2E samples to ensure the app creation and VNet integration will work. Related to issue #29. 
